### PR TITLE
Fixing bugs in the Solace Sample application

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,2 @@
+# Future TODO
+- I fixed a bug where the years of experience as a search term wouldn't be correctly parsed out of the search term. Now, an integer in the search term will be considered a minimum years of experience. A better long-term fix would be to give a more granular UX where years of experience can be separately specified.

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,2 +1,5 @@
 # Future TODO
-- I fixed a bug where the years of experience as a search term wouldn't be correctly parsed out of the search term. Now, an integer in the search term will be considered a minimum years of experience. A better long-term fix would be to give a more granular UX where years of experience can be separately specified.
+- **YEARS OF EXPERIENCE FILTER:** I fixed a bug where the years of experience as a search term wouldn't be correctly parsed out of the search term. Now, an integer in the search term will be considered a minimum years of experience. A better long-term fix would be to give a more granular UX where years of experience can be separately specified.
+- **SPECIALTIES FILTER:** In the filter code, we are using `.include()` on both string values (e.g. first name) and array values (e.g. specialties). This will produce different behavior and allow for partial text matches on the strings, but require exact matches on the whole name of a specialty. A couple of fixes could be:
+-- When filtering, iterate throught the specialties for each advocate and if any specialty for that advocate partially matches, include the advocate in the list.
+-- Provide text input specifically for specialties, allowing the user to search for and select desired specialties, then use the selected specialties to filter the providers.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,13 +58,15 @@ export default function Home() {
       <br />
       <table>
         <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>City</th>
+            <th>Degree</th>
+            <th>Specialties</th>
+            <th>Years of Experience</th>
+            <th>Phone Number</th>
+          </tr>
         </thead>
         <tbody>
           {filteredAdvocates.map((advocate) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
     document.getElementById("search-term").innerHTML = searchTerm;
 
     console.log("filtering advocates...");
+    const minimumYears = parseInt(searchTerm);
     const filteredAdvocates = advocates.filter((advocate) => {
       return (
         advocate.firstName.includes(searchTerm) ||
@@ -29,7 +30,8 @@ export default function Home() {
         advocate.city.includes(searchTerm) ||
         advocate.degree.includes(searchTerm) ||
         advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
+        // Assuming specified years of experience to be a minimum, not exact
+        (isNaN(minimumYears) ? false : advocate.yearsOfExperience >= minimumYears)
       );
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,14 +71,14 @@ export default function Home() {
         <tbody>
           {filteredAdvocates.map((advocate) => {
             return (
-              <tr>
+              <tr key={advocate.id}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
-                  {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                  {advocate.specialties.map((s, sIndex) => (
+                    <div key={sIndex}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>

--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -39,6 +39,7 @@ const randomSpecialty = () => {
 
 const advocateData = [
   {
+    id: 1,
     firstName: "John",
     lastName: "Doe",
     city: "New York",
@@ -48,6 +49,7 @@ const advocateData = [
     phoneNumber: 5551234567,
   },
   {
+    id: 2,
     firstName: "Jane",
     lastName: "Smith",
     city: "Los Angeles",
@@ -57,6 +59,7 @@ const advocateData = [
     phoneNumber: 5559876543,
   },
   {
+    id: 3,
     firstName: "Alice",
     lastName: "Johnson",
     city: "Chicago",
@@ -66,6 +69,7 @@ const advocateData = [
     phoneNumber: 5554567890,
   },
   {
+    id: 4,
     firstName: "Michael",
     lastName: "Brown",
     city: "Houston",
@@ -75,6 +79,7 @@ const advocateData = [
     phoneNumber: 5556543210,
   },
   {
+    id: 5,
     firstName: "Emily",
     lastName: "Davis",
     city: "Phoenix",
@@ -84,6 +89,7 @@ const advocateData = [
     phoneNumber: 5553210987,
   },
   {
+    id: 6,
     firstName: "Chris",
     lastName: "Martinez",
     city: "Philadelphia",
@@ -93,6 +99,7 @@ const advocateData = [
     phoneNumber: 5557890123,
   },
   {
+    id: 7,
     firstName: "Jessica",
     lastName: "Taylor",
     city: "San Antonio",
@@ -102,6 +109,7 @@ const advocateData = [
     phoneNumber: 5554561234,
   },
   {
+    id: 8,
     firstName: "David",
     lastName: "Harris",
     city: "San Diego",
@@ -111,6 +119,7 @@ const advocateData = [
     phoneNumber: 5557896543,
   },
   {
+    id: 9,
     firstName: "Laura",
     lastName: "Clark",
     city: "Dallas",
@@ -120,6 +129,7 @@ const advocateData = [
     phoneNumber: 5550123456,
   },
   {
+    id: 10,
     firstName: "Daniel",
     lastName: "Lewis",
     city: "San Jose",
@@ -129,6 +139,7 @@ const advocateData = [
     phoneNumber: 5553217654,
   },
   {
+    id: 11,
     firstName: "Sarah",
     lastName: "Lee",
     city: "Austin",
@@ -138,6 +149,7 @@ const advocateData = [
     phoneNumber: 5551238765,
   },
   {
+    id: 12,
     firstName: "James",
     lastName: "King",
     city: "Jacksonville",
@@ -147,6 +159,7 @@ const advocateData = [
     phoneNumber: 5556540987,
   },
   {
+    id: 13,
     firstName: "Megan",
     lastName: "Green",
     city: "San Francisco",
@@ -156,6 +169,7 @@ const advocateData = [
     phoneNumber: 5559873456,
   },
   {
+    id: 14,
     firstName: "Joshua",
     lastName: "Walker",
     city: "Columbus",
@@ -165,6 +179,7 @@ const advocateData = [
     phoneNumber: 5556781234,
   },
   {
+    id: 15,
     firstName: "Amanda",
     lastName: "Hall",
     city: "Fort Worth",


### PR DESCRIPTION
This PR fixes some errors and functional bugs in the advocate list page, and includes some discussion suggestions for future changes.

- **Bugfix** The page was not filtering on years of experience properly, and the page was generating an error for trying to use the `.includes()` function on a number value. I added some logic to parse out integer values from the search term as years of experience, and to filter the results for advocates who have at least that many years of experience.
- **Warning Fix** The header cells for the table weren't included in a header row. I added a header row.
- **Warning Fix** The lists generated in the page (list of advocates, list of specialties per advocate) weren't including keys in their populated react elements. I added IDs for the advocates to set those keys, setting up more involved UX functions on advocates in the future. For the specialties, I added the generated indexes as a quick solution, assuming we're less likely to manipulate the listed specialties.

I added some discussion items for possible future work:
- Filtering by years of experience would benefit from having a separate input in the UX.
- The specialty filtering is inconsistent with how other fields are filtered. This could be improved with better UX.